### PR TITLE
Remove IsLoadable check

### DIFF
--- a/Projects/DELibrary.NET Testing/DotNetTest.h
+++ b/Projects/DELibrary.NET Testing/DotNetTest.h
@@ -43,13 +43,6 @@ ICorRuntimeHost* getCorRtHost_byVersion(LPCWSTR sz_runtimeVersion) {
     }
     else printf("[+] pMetaHost->GetRuntime(...) succeeded\n");
 
-    /* Check if the specified runtime can be loaded */
-    if (FAILED(pRuntimeInfo->IsLoadable(&bLoadable)) || !bLoadable) {
-        printf("[!] pRuntimeInfo->IsLoadable(...) failed\n");
-        return NULL;
-    }
-    else printf("[+] pRuntimeInfo->IsLoadable(...) succeeded\n");
-
     /* Get ICorRuntimeHost instance */
     if (FAILED(pRuntimeInfo->GetInterface(CLSID_CorRuntimeHost, IID_ICorRuntimeHost, (VOID**)&pRuntimeHost))) {
         printf("[!] pRuntimeInfo->GetInterface(...) failed\n");


### PR DESCRIPTION
Since we're only ever loading .NET 4 or later into the process, this check isn't really needed (see [here](https://learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/hosting/iclrruntimeinfo-isloadable-method))

Additionally, this allows .NET mods to run with Wine's Mono runtime where IsLoadable is unimplemented