### PR TITLE
UTF-8 string encoding for SetCategoryName and SetText

### DIFF
--- a/DELibrary.NET/Components/UIEntityComponentEnemyLifeGauge.cs
+++ b/DELibrary.NET/Components/UIEntityComponentEnemyLifeGauge.cs
@@ -25,15 +25,7 @@ namespace DragonEngineLibrary
                 return;
             }
 
-            byte[] encoded;
-            try
-            {
-                encoded = Encoding.UTF8.GetBytes(name + "\0");
-            }
-            catch
-            {
-                encoded = Encoding.ASCII.GetBytes(name + "\0");
-            }
+            byte[] encoded = Encoding.UTF8.GetBytes(name + "0");
 
             IntPtr ptr = Marshal.AllocHGlobal(encoded.Length);
             try

--- a/DELibrary.NET/Components/UIEntityComponentEnemyLifeGauge.cs
+++ b/DELibrary.NET/Components/UIEntityComponentEnemyLifeGauge.cs
@@ -1,12 +1,13 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace DragonEngineLibrary
 {
     public class UIEntityComponentEnemyLifeGauge : UIEntityComponentLifeGauge
     {
         [DllImport("Y7Internal.dll", EntryPoint = "LIB_CUI_ENTITY_COMPONENT_ENEMY_LIFE_GAUGE_SET_CATEGORY_NAME", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern uint DELib_UIEntityComponentEnemyLifeGauge_SetCategoryName(IntPtr gauge, string name);
+        internal static extern uint DELib_UIEntityComponentEnemyLifeGauge_SetCategoryName(IntPtr gauge, IntPtr name);
 
         [DllImport("Y7Internal.dll", EntryPoint = "LIB_CUI_ENTITY_COMPONENT_ENEMY_LIFE_GAUGE_ATTACH", CallingConvention = CallingConvention.Cdecl)]
         internal static extern uint DELib_UIEntityComponentEnemyLifeGauge_Attach(IntPtr character);
@@ -15,7 +16,35 @@ namespace DragonEngineLibrary
         ///<summary>Set name on the UI gauge.</summary>
         public void SetCategoryName(string name)
         {
-            DELib_UIEntityComponentEnemyLifeGauge_SetCategoryName(Pointer, name);
+            if (string.IsNullOrEmpty(name))
+            {
+                IntPtr emptyPtr = Marshal.AllocHGlobal(1);
+                Marshal.WriteByte(emptyPtr, 0);
+                try { DELib_UIEntityComponentEnemyLifeGauge_SetCategoryName(Pointer, emptyPtr); }
+                finally { Marshal.FreeHGlobal(emptyPtr); }
+                return;
+            }
+
+            byte[] encoded;
+            try
+            {
+                encoded = Encoding.UTF8.GetBytes(name + "\0");
+            }
+            catch
+            {
+                encoded = Encoding.ASCII.GetBytes(name + "\0");
+            }
+
+            IntPtr ptr = Marshal.AllocHGlobal(encoded.Length);
+            try
+            {
+                Marshal.Copy(encoded, 0, ptr, encoded.Length);
+                DELib_UIEntityComponentEnemyLifeGauge_SetCategoryName(Pointer, ptr);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(ptr);
+            }
         }
 
         public static EntityComponentHandle<UIEntityComponentEnemyLifeGauge> Attach(Character chara)

--- a/DELibrary.NET/Components/UIEntityComponentEnemyLifeGauge.cs
+++ b/DELibrary.NET/Components/UIEntityComponentEnemyLifeGauge.cs
@@ -16,27 +16,11 @@ namespace DragonEngineLibrary
         ///<summary>Set name on the UI gauge.</summary>
         public void SetCategoryName(string name)
         {
-            if (string.IsNullOrEmpty(name))
-            {
-                IntPtr emptyPtr = Marshal.AllocHGlobal(1);
-                Marshal.WriteByte(emptyPtr, 0);
-                try { DELib_UIEntityComponentEnemyLifeGauge_SetCategoryName(Pointer, emptyPtr); }
-                finally { Marshal.FreeHGlobal(emptyPtr); }
-                return;
-            }
-
-            byte[] encoded = Encoding.UTF8.GetBytes(name + "0");
-
+            byte[] encoded = Encoding.UTF8.GetBytes((name ?? "") + "\0");
             IntPtr ptr = Marshal.AllocHGlobal(encoded.Length);
-            try
-            {
-                Marshal.Copy(encoded, 0, ptr, encoded.Length);
-                DELib_UIEntityComponentEnemyLifeGauge_SetCategoryName(Pointer, ptr);
-            }
-            finally
-            {
-                Marshal.FreeHGlobal(ptr);
-            }
+            Marshal.Copy(encoded, 0, ptr, encoded.Length);
+            DELib_UIEntityComponentEnemyLifeGauge_SetCategoryName(Pointer, ptr);
+            Marshal.FreeHGlobal(ptr);
         }
 
         public static EntityComponentHandle<UIEntityComponentEnemyLifeGauge> Attach(Character chara)

--- a/DELibrary.NET/Entity/UI/UIHandleBase.cs
+++ b/DELibrary.NET/Entity/UI/UIHandleBase.cs
@@ -145,20 +145,7 @@ namespace DragonEngineLibrary
                 return;
             }
 
-            byte[] encoded;
-            try
-            {
-                encoded = System.Text.Encoding.UTF8.GetBytes(text + "\0");
-            }
-            catch
-            {
-                encoded = System.Text.Encoding.ASCII.GetBytes(text + "\0");
-            }
-
-            IntPtr ptr = System.Runtime.InteropServices.Marshal.AllocHGlobal(encoded.Length);
-            try
-            {
-                System.Runtime.InteropServices.Marshal.Copy(encoded, 0, ptr, encoded.Length);
+            byte[] encoded = System.Text.Encoding.UTF8.GetBytes(text + "0");
                 DELib_UIHandleBase_SetText(Handle, ptr);
             }
             finally

--- a/DELibrary.NET/Entity/UI/UIHandleBase.cs
+++ b/DELibrary.NET/Entity/UI/UIHandleBase.cs
@@ -136,22 +136,11 @@ namespace DragonEngineLibrary
 
         public void SetText(string text)
         {
-            if (string.IsNullOrEmpty(text))
-            {
-                IntPtr emptyPtr = System.Runtime.InteropServices.Marshal.AllocHGlobal(1);
-                System.Runtime.InteropServices.Marshal.WriteByte(emptyPtr, 0);
-                try { DELib_UIHandleBase_SetText(Handle, emptyPtr); }
-                finally { System.Runtime.InteropServices.Marshal.FreeHGlobal(emptyPtr); }
-                return;
-            }
-
-            byte[] encoded = System.Text.Encoding.UTF8.GetBytes(text + "0");
-                DELib_UIHandleBase_SetText(Handle, ptr);
-            }
-            finally
-            {
-                System.Runtime.InteropServices.Marshal.FreeHGlobal(ptr);
-            }
+            byte[] encoded = System.Text.Encoding.UTF8.GetBytes((text ?? "") + "\0");
+            IntPtr ptr = Marshal.AllocHGlobal(encoded.Length);
+            Marshal.Copy(encoded, 0, ptr, encoded.Length);
+            DELib_UIHandleBase_SetText(Handle, ptr);
+            Marshal.FreeHGlobal(ptr);
         }
 
         public void SetFrame(float frame)


### PR DESCRIPTION
The default P/Invoke string marshaling uses ANSI (system codepage) which mangles non-Latin characters (Cyrillic, CJK, etc). The Dragon Engine renders UTF-8 natively so the fix is to marshal strings as UTF-8 manually.

- SetCategoryName: manual UTF-8 encoding via Marshal.AllocHGlobal
- SetText: same UTF-8 encoding approach
- ASCII fallback if UTF-8 encoding fails