### PR TITLE
Improve logging system

### DIFF
--- a/DELibrary.NET/DELibrary.NET.csproj
+++ b/DELibrary.NET/DELibrary.NET.csproj
@@ -608,6 +608,7 @@
     <Compile Include="Enums\VirtualKey.cs" />
     <Compile Include="Enums\Yakuza 7\MinigameDragonKartCourseID.cs" />
     <Compile Include="Enums\Yakuza 7\MinigameDragonKartDriverID.cs" />
+    <Compile Include="Logger.cs" />
     <Compile Include="Structs\ExEffectInfo.cs" />
     <Compile Include="Utils\Extensions.cs" />
     <Compile Include="Entity\Yakuza 7\FighterManager.cs" />

--- a/DELibrary.NET/Logger.cs
+++ b/DELibrary.NET/Logger.cs
@@ -1,0 +1,185 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+
+namespace DragonEngineLibrary
+{
+    public class Logger
+    {
+        /// <summary>
+        /// Represents a logged message. This information includes a source, creation timestamp, event type and message.
+        /// </summary>
+        public struct LogMessage
+        {
+            /// <summary>
+            /// The source of this log.
+            /// </summary>
+            public string Source;
+            
+            /// <summary>
+            /// The creation time of this log.
+            /// </summary>
+            public DateTime Time;
+
+            /// <summary>
+            /// The event type of this log.
+            /// </summary>
+            public Event Event;
+
+            /// <summary>
+            /// The message of this log.
+            /// </summary>
+            public string Message;
+
+
+            /// <summary>
+            /// Returns the log's information in the following format: Timestamp (HH:mm:ss.fff) | Event | Source
+            /// </summary>
+            public string GetLogInfoString()
+            {
+                return $"{Time.ToString("HH:mm:ss.fff")} | {EventStrings[(int)Event]} | [{Source}]";
+            }
+
+            /// <summary>
+            /// Returns this log's message preceded by its timestamp, event type and source.
+            /// </summary>
+            public override string ToString()
+            {
+                return $"{GetLogInfoString()} {Message}";
+            }
+        }
+
+
+        /// <summary>
+        /// Contains all logs in order of submission.
+        /// </summary>
+        public static volatile ConcurrentQueue<LogMessage> Logs = new ConcurrentQueue<LogMessage>();
+
+
+        /// <summary>
+        /// Event type.
+        /// </summary>
+        public enum Event
+        {
+            DEBUG,
+            INFORMATION,
+            WARNING,
+            ERROR,
+            FATAL,
+        }
+
+
+        /// <summary>
+        /// Shortened name for each <see cref="Event"/>.
+        /// </summary>
+        private static List<string> EventStrings = new List<string>()
+        {
+            "DBG",
+            "INF",
+            "WRN",
+            "ERR",
+            "FTL",
+        };
+
+
+        /// <summary>
+        /// Event colors in ABGR format for ImGui.
+        /// </summary>
+        private static List<uint> EventColorsABGR = new List<uint>()
+        {
+            0x80333333, // DEBUG
+            0x00000000, // INFORMATION
+            0x800070EE, // WARNING
+            0x800000EE, // ERROR
+            0x80BF0898, // FATAL
+        };
+
+
+        /// <summary>
+        /// Event colors for consoles/terminals.
+        /// </summary>
+        private static List<ConsoleColor> EventColorsConsole = new List<ConsoleColor>()
+        {
+            ConsoleColor.Gray,      // DEBUG
+            ConsoleColor.White,     // INFORMATION
+            ConsoleColor.Yellow,    // WARNING
+            ConsoleColor.Red,       // ERROR
+            ConsoleColor.Magenta,   // FATAL
+        };
+
+
+        /// <summary>
+        /// Gets the specified <see cref="Event"/>'s color in ABGR format to be used in ImGui.
+        /// </summary>
+        /// <param name="eventType">The event type.</param>
+        /// <returns>An ABGR color as <see cref="uint"/>.</returns>
+        public static uint GetABGRColorForLogEventType(Event eventType)
+        {
+            return EventColorsABGR[(int)eventType];
+        }
+
+
+        /// <summary>
+        /// Gets the specified <see cref="Event"/>'s color as <see cref="ConsoleColor"/> to be used in a terminal.
+        /// </summary>
+        /// <param name="eventType">The event type.</param>
+        /// <returns>The color as <see cref="ConsoleColor"/>.</returns>
+        public static ConsoleColor GetConsoleColorForLogEventType(Event eventType)
+        {
+            return EventColorsConsole[(int)eventType];
+        }
+
+
+        /// <summary>
+        /// Logs an event with its corresponding message and source.
+        /// </summary>
+        /// <param name="message">The log message.</param>
+        /// <param name="source">The source of the log.</param>
+        /// <param name="eventType">The event type.</param>
+        internal static void LogEvent(string message, string source, Event eventType)
+        {
+            LogMessage logMessage = new LogMessage()
+            {
+                Source = source,
+                Time = DateTime.Now,
+                Event = eventType,
+                Message = message
+            };
+            Logs.Enqueue(logMessage);
+
+            string logMessageString = logMessage.ToString();
+            try
+            {
+                File.AppendAllText("de_log.txt", logMessageString + "\n");
+            }
+            catch { }
+            Console.ForegroundColor = GetConsoleColorForLogEventType(eventType);
+            Console.WriteLine(logMessageString);
+            Console.ResetColor();
+        }
+
+
+        /// <summary>
+        /// Gets a list of logs filtered by source and event type.
+        /// </summary>
+        /// <param name="source">The source to filter for. A null or empty value will include all sources.</param>
+        /// <param name="logEvents">The event types to filter for. A null or empty value will include all event types.</param>
+        /// <returns>A <see cref="LogMessage"/> list.</returns>
+        public static List<LogMessage> GetFilteredLogs(string source, List<Event> logEvents)
+        {
+            var filtered = new List<LogMessage>();
+
+            foreach (var logMessage in Logs)
+            {
+                if (!string.IsNullOrEmpty(source) && logMessage.Source != source)
+                    continue;
+
+                if (logEvents == null || logEvents.Count == 0 || logEvents.Contains(logMessage.Event))
+                    filtered.Add(logMessage);
+            }
+
+            return filtered;
+        }
+    }
+}

--- a/DELibrary.NET/Program.cs
+++ b/DELibrary.NET/Program.cs
@@ -28,7 +28,7 @@ namespace DragonEngineLibrary
         {
             try
             {
-                DragonEngine.Log("\nDragon Engine Library .NET Thread Start");
+                DragonEngine.Log("Dragon Engine Library .NET Thread Start");
                 File.WriteAllText("de_log.txt", "");
 
                 DragonEngine.RefreshOffsets();
@@ -38,12 +38,12 @@ namespace DragonEngineLibrary
                     DragonEngine.RefreshOffsets();
                 }
 
-                DragonEngine.Log("Dragon Engine initialized, initializing the library.\n");
+                DragonEngine.Log("Dragon Engine initialized, initializing the library.");
                 StartEngine();
             }
             catch (Exception ex)
             {
-                DragonEngine.Log("\n\n\nFailed to initialize\nError:" + ex.Message + "\n\nStacktrace:\n" + ex.StackTrace);
+                DragonEngine.Log($"Failed to initialize\nError:{ex.Message}\n\nStacktrace:\n{ex.StackTrace}", Logger.Event.ERROR);
             }
 
 
@@ -52,7 +52,7 @@ namespace DragonEngineLibrary
         private static void StartEngine()
         {
             DragonEngine.Log("Starting initializaton of all mods.");
-            DragonEngine.Log("Path: " + AppDomain.CurrentDomain.BaseDirectory + "\n");
+            DragonEngine.Log($"Path: {AppDomain.CurrentDomain.BaseDirectory}");
 
 
             Thread modsThread = new Thread(LibThread);
@@ -111,13 +111,13 @@ namespace DragonEngineLibrary
                     bool loadRes = DragonEngine.InitializeModLibrary(Path.Combine(directory, dllFile));
 
                     if (loadRes)
-                        DragonEngine.Log("Successfully loaded DLL library in " + new DirectoryInfo(directory).Name);
+                        DragonEngine.Log($"Successfully loaded DLL library in {new DirectoryInfo(directory).Name}");
                     else
-                        DragonEngine.Log("Failed to load DLL library in " + new DirectoryInfo(directory).Name);
+                        DragonEngine.Log($"Failed to load DLL library in {new DirectoryInfo(directory).Name}", Logger.Event.ERROR);
                 }
             }
 
-            DragonEngine.Log("\n\nAll mods have been initialized.");
+            DragonEngine.Log("All mods have been initialized.");
         }
 
 
@@ -166,12 +166,12 @@ namespace DragonEngineLibrary
 
             //Create seperate thread for our C# library
             DragonEngine.Log("DragonEngine Library .Net Main Start");
-            DragonEngine.Log("BaseDirectory: " + BaseDirectory);
-            DragonEngine.Log("RootDirectory: " + Root);
+            DragonEngine.Log($"BaseDirectory: {BaseDirectory}");
+            DragonEngine.Log($"RootDirectory: {Root}");
 
             if(!ShouldInitialize())
             {
-                DragonEngine.Log("There is no need to initialize the library. No compatible mods detected. Aborting.");
+                DragonEngine.Log("There is no need to initialize the library. No compatible mods detected. Aborting.", Logger.Event.WARNING);
                 return;
             }
 


### PR DESCRIPTION
* Added a `Logger` class to handle log requests and keep a history of logged messages.
This log history is exposed for mods to access.

* Logged messages will be printed preceded by a timestamp, shortened log event type and mod name.
Example:
`22:32:10.442 | WRN | [TestMod] This is a test warning message!`
Depending on their type, they will be printed with different colors to the console. A separate set of color presets to be used for ImGui elements is also provided.

* Cleaned up existing logs and gave them an event type when applicable. 
* `DragonEngine.Log()` calls that do not specify an event type will default to `INFORMATION`, which has no distinctive color.