### PR TITLE
Upgrade to .NET 10 and add a hostfxr native host

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
           cd DELibInitializer
           mkdir -p build/x64
           cd build/x64
-          cmake -G "Visual Studio 17 2022" -DCMAKE_GENERATOR_PLATFORM=x64 ../..
+          cmake -DCMAKE_GENERATOR_PLATFORM=x64 ../..
 
       - name: Build DELibInitializer.asi
         run: cmake --build DELibInitializer/build/x64 --config Release
@@ -50,9 +50,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: delibinit
-          path: |
-            DELibInitializer/build/x64/Release/DELibInitializer.asi
-            DELibInitializer/build/x64/Release/nethost.dll
+          path: DELibInitializer/build/x64/Release/DELibInitializer.asi
 
   build-delib:
     runs-on: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
   build-cimgui:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Configure CMake
         shell: bash
@@ -22,7 +22,7 @@ jobs:
       - name: Build cimgui.dll
         run: cmake --build deps/dxhook/build/x64 --config Release
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: cimgui
           path: deps/dxhook/build/x64/Release/cimgui.dll
@@ -30,9 +30,9 @@ jobs:
   build-delibinit:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
 
@@ -47,7 +47,7 @@ jobs:
       - name: Build DELibInitializer.asi
         run: cmake --build DELibInitializer/build/x64 --config Release
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: delibinit
           path: DELibInitializer/build/x64/Release/DELibInitializer.asi
@@ -67,23 +67,23 @@ jobs:
           - config: "Gaiden Release"
             artifact: DELibrary.Gaiden
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: false
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
 
       - name: Build DELibrary.NET
         run: dotnet build DELibrary.NET/DELibrary.NET.csproj -c "${{ matrix.config }}" -p:Platform=x64
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: cimgui
           path: staging
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: delibinit
           path: staging
@@ -100,7 +100,7 @@ jobs:
           cp "${outdir}"/*.deps.json staging/ 2>/dev/null || true
           cp "${outdir}"/*.runtimeconfig.json staging/ 2>/dev/null || true
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: staging/*
@@ -112,7 +112,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: artifacts
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,36 @@ jobs:
           name: cimgui
           path: deps/dxhook/build/x64/Release/cimgui.dll
 
+  build-delibinit:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Configure CMake
+        shell: bash
+        run: |
+          cd DELibInitializer
+          mkdir -p build/x64
+          cd build/x64
+          cmake -G "Visual Studio 17 2022" -DCMAKE_GENERATOR_PLATFORM=x64 ../..
+
+      - name: Build DELibInitializer.asi
+        run: cmake --build DELibInitializer/build/x64 --config Release
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: delibinit
+          path: |
+            DELibInitializer/build/x64/Release/DELibInitializer.asi
+            DELibInitializer/build/x64/Release/nethost.dll
+
   build-delib:
     runs-on: windows-latest
-    needs: build-cimgui
+    needs: [build-cimgui, build-delibinit]
     strategy:
       matrix:
         include:
@@ -46,6 +73,10 @@ jobs:
         with:
           submodules: false
 
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
       - name: Build DELibrary.NET
         run: dotnet build DELibrary.NET/DELibrary.NET.csproj -c "${{ matrix.config }}" -p:Platform=x64
 
@@ -54,15 +85,22 @@ jobs:
           name: cimgui
           path: staging
 
+      - uses: actions/download-artifact@v4
+        with:
+          name: delibinit
+          path: staging
+
       - name: Stage release files
         shell: bash
         run: |
           cfg="${{ matrix.config }}"
           outdir="DELibrary.NET/bin/x64/${cfg}"
-          # DELibrary.NET outputs .dll directly (OutputType=WinExe + TargetExt=.dll)
-          cp "${outdir}/DELibrary.NET.dll" staging/
-          cp "${outdir}/Newtonsoft.Json.dll" staging/ 2>/dev/null || true
-          cp "${outdir}/MinHook.NET.dll" staging/ 2>/dev/null || true
+          # DELibrary.NET outputs .dll directly (OutputType=WinExe + TargetExt=.dll).
+          # Dependencies (ImGui/ImPlot/ImNodes/ImGuizmo/HexaGen.Runtime) are no longer
+          # merged in via Costura, so they need to ship alongside as separate files.
+          cp "${outdir}"/*.dll staging/
+          cp "${outdir}"/*.deps.json staging/ 2>/dev/null || true
+          cp "${outdir}"/*.runtimeconfig.json staging/ 2>/dev/null || true
 
       - uses: actions/upload-artifact@v4
         with:
@@ -96,3 +134,7 @@ jobs:
             --title "${{ github.ref_name }}" \
             --generate-notes \
             DELibrary.*.zip
+
+      - name: Remind to submit release for AV false-positive review
+        run: |
+          echo "::notice::New release ${{ github.ref_name }} is up. Since these DLLs hook and inject into a game process, some AVs may flag them. Consider submitting the zips to https://www.microsoft.com/en-us/wdsi/filesubmission (and other vendors via VirusTotal) for a false-positive review. This has to be done manually, there's no anonymous API for automated submission."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,8 @@
-name: Build & Release
+name: Build
 
 on:
   push:
     branches: [main]
-    tags: ['*']
 
 jobs:
   build-cimgui:
@@ -104,35 +103,3 @@ jobs:
         with:
           name: ${{ matrix.artifact }}
           path: staging/*
-
-  release:
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    needs: build-delib
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          path: artifacts
-
-      - name: Create release zips
-        run: |
-          for dir in artifacts/DELibrary.*; do
-            name=$(basename "$dir")
-            (cd "$dir" && zip -r "../../${name}.zip" .)
-          done
-
-      - name: Create GitHub release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release create "${{ github.ref_name }}" \
-            --repo "${{ github.repository }}" \
-            --title "${{ github.ref_name }}" \
-            --generate-notes \
-            DELibrary.*.zip
-
-      - name: Remind to submit release for AV false-positive review
-        run: |
-          echo "::notice::New release ${{ github.ref_name }} is up. Since these DLLs hook and inject into a game process, some AVs may flag them. Consider submitting the zips to https://www.microsoft.com/en-us/wdsi/filesubmission (and other vendors via VirusTotal) for a false-positive review. This has to be done manually, there's no anonymous API for automated submission."

--- a/.gitignore
+++ b/.gitignore
@@ -352,6 +352,7 @@ MigrationBackup/
 # CMake build output
 /build/
 deps/dxhook/build/
+DELibInitializer/build/
 
 # Linker artifacts
 deps/prebuilt-libs/*.lib

--- a/DELibInitializer/CMakeLists.txt
+++ b/DELibInitializer/CMakeLists.txt
@@ -10,17 +10,31 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # (there can be several SDK feature bands installed side by side) and pick
 # the newest 10.x version present rather than hardcoding an exact patch.
 if(NOT DEFINED DOTNET_HOST_PACK_DIR)
-    if(NOT DEFINED ENV{ProgramFiles})
-        message(FATAL_ERROR "ProgramFiles environment variable is not set")
+    # The apphost pack can live under a few roots depending on how .NET was
+    # installed: the default Program Files location locally, or wherever
+    # DOTNET_ROOT points (that's where actions/setup-dotnet drops it on CI).
+    set(DOTNET_PACK_ROOTS "")
+    if(DEFINED ENV{DOTNET_ROOT})
+        list(APPEND DOTNET_PACK_ROOTS "$ENV{DOTNET_ROOT}")
+    endif()
+    if(DEFINED ENV{ProgramFiles})
+        list(APPEND DOTNET_PACK_ROOTS "$ENV{ProgramFiles}/dotnet")
     endif()
 
-    file(GLOB DOTNET_HOST_PACK_CANDIDATES
-        "$ENV{ProgramFiles}/dotnet/packs/Microsoft.NETCore.App.Host.win-x64/10.*"
-    )
+    if(NOT DOTNET_PACK_ROOTS)
+        message(FATAL_ERROR "Neither DOTNET_ROOT nor ProgramFiles is set, cannot locate the .NET host pack")
+    endif()
+
+    set(DOTNET_HOST_PACK_CANDIDATES "")
+    foreach(root ${DOTNET_PACK_ROOTS})
+        file(GLOB _candidates
+            "${root}/packs/Microsoft.NETCore.App.Host.win-x64/10.*")
+        list(APPEND DOTNET_HOST_PACK_CANDIDATES ${_candidates})
+    endforeach()
 
     if(NOT DOTNET_HOST_PACK_CANDIDATES)
         message(FATAL_ERROR "Could not find a .NET 10 Microsoft.NETCore.App.Host.win-x64 pack "
-                             "under $ENV{ProgramFiles}/dotnet/packs. Install the .NET 10 SDK.")
+                             "under any of: ${DOTNET_PACK_ROOTS}. Install the .NET 10 SDK.")
     endif()
 
     list(SORT DOTNET_HOST_PACK_CANDIDATES COMPARE NATURAL)

--- a/DELibInitializer/CMakeLists.txt
+++ b/DELibInitializer/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.18)
+cmake_policy(SET CMP0091 NEW)
+project(DELibInitializer)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# nethost.h/hostfxr.h/coreclr_delegates.h and nethost.lib ship as part of the
+# .NET SDK's win-x64 apphost pack. Pin to the .NET 10 pack specifically
+# (there can be several SDK feature bands installed side by side) and pick
+# the newest 10.x version present rather than hardcoding an exact patch.
+if(NOT DEFINED DOTNET_HOST_PACK_DIR)
+    if(NOT DEFINED ENV{ProgramFiles})
+        message(FATAL_ERROR "ProgramFiles environment variable is not set")
+    endif()
+
+    file(GLOB DOTNET_HOST_PACK_CANDIDATES
+        "$ENV{ProgramFiles}/dotnet/packs/Microsoft.NETCore.App.Host.win-x64/10.*"
+    )
+
+    if(NOT DOTNET_HOST_PACK_CANDIDATES)
+        message(FATAL_ERROR "Could not find a .NET 10 Microsoft.NETCore.App.Host.win-x64 pack "
+                             "under $ENV{ProgramFiles}/dotnet/packs. Install the .NET 10 SDK.")
+    endif()
+
+    list(SORT DOTNET_HOST_PACK_CANDIDATES COMPARE NATURAL)
+    list(GET DOTNET_HOST_PACK_CANDIDATES -1 DOTNET_HOST_PACK_LATEST)
+    set(DOTNET_HOST_PACK_DIR "${DOTNET_HOST_PACK_LATEST}/runtimes/win-x64/native")
+endif()
+
+message(STATUS "DELibInitializer: using .NET host pack at ${DOTNET_HOST_PACK_DIR}")
+
+add_library(DELibInitializer SHARED
+    dllmain.cpp
+    DotNetHost.cpp
+)
+
+target_include_directories(DELibInitializer PRIVATE ${DOTNET_HOST_PACK_DIR})
+target_link_directories(DELibInitializer PRIVATE ${DOTNET_HOST_PACK_DIR})
+# Static libnethost.lib (paired with NETHOST_USE_AS_STATIC in DotNetHost.h) so
+# the .asi has no runtime dependency on nethost.dll being resolvable next to it.
+target_link_libraries(DELibInitializer PRIVATE libnethost)
+
+# Ships as a .asi (loaded by the game's ASI loader), matching the existing
+# DELibInitializer.asi naming already deployed alongside DELibrary.NET.
+set_target_properties(DELibInitializer PROPERTIES
+    PREFIX ""
+    SUFFIX ".asi"
+)
+set_property(TARGET DELibInitializer PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded")

--- a/DELibInitializer/DotNetHost.cpp
+++ b/DELibInitializer/DotNetHost.cpp
@@ -1,0 +1,142 @@
+#include "DotNetHost.h"
+
+namespace
+{
+    //--------------------------------------------------------------------
+    // Loads hostfxr.dll using Microsoft's nethost library.
+    //--------------------------------------------------------------------
+    bool LoadHostFxrLibrary(HMODULE& module)
+    {
+        wchar_t buffer[MAX_PATH];
+
+        size_t bufferSize = sizeof(buffer) / sizeof(wchar_t);
+
+        int rc = get_hostfxr_path(buffer, &bufferSize, nullptr);
+
+        if (rc != 0)
+            return false;
+
+        module = ::LoadLibraryW(buffer);
+
+        return module != nullptr;
+    }
+
+    template<typename T>
+    T GetExport(HMODULE module, const char* name)
+    {
+        return reinterpret_cast<T>(
+            ::GetProcAddress(module, name));
+    }
+}
+
+DotNetHost::DotNetHost()
+{
+}
+
+DotNetHost::~DotNetHost()
+{
+    Shutdown();
+}
+
+bool DotNetHost::IsInitialized() const
+{
+    return m_initialized;
+}
+
+bool DotNetHost::LoadHostFxr()
+{
+    if (!LoadHostFxrLibrary(m_hostfxrModule))
+        return false;
+
+    m_initialize =
+        GetExport<hostfxr_initialize_for_runtime_config_fn>(
+            m_hostfxrModule,
+            "hostfxr_initialize_for_runtime_config");
+
+    m_getDelegate =
+        GetExport<hostfxr_get_runtime_delegate_fn>(
+            m_hostfxrModule,
+            "hostfxr_get_runtime_delegate");
+
+    m_close =
+        GetExport<hostfxr_close_fn>(
+            m_hostfxrModule,
+            "hostfxr_close");
+
+    if (!m_initialize)
+        return false;
+
+    if (!m_getDelegate)
+        return false;
+
+    if (!m_close)
+        return false;
+
+    return true;
+}
+
+void DotNetHost::Shutdown()
+{
+    if (m_hostfxrHandle)
+    {
+        m_close(m_hostfxrHandle);
+        m_hostfxrHandle = nullptr;
+    }
+
+    if (m_hostfxrModule)
+    {
+        FreeLibrary(m_hostfxrModule);
+        m_hostfxrModule = nullptr;
+    }
+
+    m_loadAssembly = nullptr;
+
+    m_initialized = false;
+}
+
+bool DotNetHost::Initialize(const std::wstring& runtimeConfigPath)
+{
+    if (m_initialized)
+        return true;
+
+    if (!LoadHostFxr())
+        return false;
+
+    if (!LoadAssemblyDelegate(runtimeConfigPath))
+        return false;
+
+    m_initialized = true;
+
+    return true;
+}
+
+bool DotNetHost::LoadAssemblyDelegate(const std::wstring& runtimeConfigPath)
+{
+    hostfxr_handle context = nullptr;
+
+    int rc = m_initialize(
+        runtimeConfigPath.c_str(),
+        nullptr,
+        &context);
+
+    if (rc != 0 || context == nullptr)
+        return false;
+
+    void* delegate = nullptr;
+
+    rc = m_getDelegate(
+        context,
+        hdt_load_assembly_and_get_function_pointer,
+        &delegate);
+
+    // We don't need the initialization context anymore.
+    m_close(context);
+
+    if (rc != 0 || delegate == nullptr)
+        return false;
+
+    m_loadAssembly =
+        reinterpret_cast<load_assembly_and_get_function_pointer_fn>(delegate);
+
+    return true;
+}

--- a/DELibInitializer/DotNetHost.h
+++ b/DELibInitializer/DotNetHost.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <Windows.h>
+#include <string>
+
+// Statically link nethost so DELibInitializer.asi has no runtime dependency on
+// nethost.dll. Some ASI loaders LoadLibrary plugins with a restricted search
+// scope that doesn't include the plugin's own directory, which broke resolution
+// of a co-located nethost.dll (LoadLibrary failed with error 126).
+#define NETHOST_USE_AS_STATIC
+#include <nethost.h>
+#include <hostfxr.h>
+#include <coreclr_delegates.h>
+
+#pragma comment(lib, "libnethost.lib")
+
+class DotNetHost
+{
+public:
+
+    DotNetHost();
+    ~DotNetHost();
+
+    // Starts CoreCLR using the specified runtimeconfig.json.
+    bool Initialize(const std::wstring& runtimeConfigPath);
+
+    // Returns whether the runtime has been initialized.
+    bool IsInitialized() const;
+
+    // Releases the runtime.
+    void Shutdown();
+
+    // Looks up any static managed method and returns its native function pointer.
+    template<typename T>
+    bool GetManagedFunction(
+        const std::wstring& assemblyPath,
+        const std::wstring& typeName,
+        const std::wstring& methodName,
+        const std::wstring& delegateTypeName,
+        T& function)
+    {
+        if (!m_initialized || !m_loadAssembly)
+            return false;
+
+        void* delegate = nullptr;
+
+        int rc = m_loadAssembly(
+            assemblyPath.c_str(),
+            typeName.c_str(),
+            methodName.c_str(),
+            delegateTypeName.empty() ? nullptr : delegateTypeName.c_str(),
+            nullptr,
+            &delegate);
+
+        if (rc != 0 || delegate == nullptr)
+            return false;
+
+        function = reinterpret_cast<T>(delegate);
+
+        return true;
+    }
+
+private:
+
+    bool LoadHostFxr();
+    bool LoadAssemblyDelegate(const std::wstring& runtimeConfigPath);
+
+private:
+
+    bool m_initialized = false;
+
+    HMODULE m_hostfxrModule = nullptr;
+
+    hostfxr_handle m_hostfxrHandle = nullptr;
+
+    hostfxr_initialize_for_runtime_config_fn
+        m_initialize = nullptr;
+
+    hostfxr_get_runtime_delegate_fn
+        m_getDelegate = nullptr;
+
+    hostfxr_close_fn
+        m_close = nullptr;
+
+    load_assembly_and_get_function_pointer_fn
+        m_loadAssembly = nullptr;
+};

--- a/DELibInitializer/dllmain.cpp
+++ b/DELibInitializer/dllmain.cpp
@@ -1,0 +1,127 @@
+#include <Windows.h>
+#include <string>
+#include <cstdio>
+#include <cstdarg>
+#include "DotNetHost.h"
+
+namespace
+{
+    FILE* g_LogFile = nullptr;
+
+    std::wstring GetParentPath(const std::wstring& path)
+    {
+        size_t pos = path.find_last_of(L"/\\");
+        return pos == std::wstring::npos ? L"" : path.substr(0, pos);
+    }
+
+    std::wstring JoinPath(const std::wstring& dir, const std::wstring& file)
+    {
+        if (dir.empty())
+            return file;
+        wchar_t lastChar = dir.back();
+        return (lastChar == L'/' || lastChar == L'\\') ? dir + file : dir + L"\\" + file;
+    }
+
+    std::wstring GetModuleDirectory(HMODULE module)
+    {
+        wchar_t path[MAX_PATH];
+        DWORD len = GetModuleFileNameW(module, path, MAX_PATH);
+        if (len == 0 || len == MAX_PATH)
+            return L"";
+        return GetParentPath(std::wstring(path, len));
+    }
+
+    void OpenLogFile(const std::wstring& directory)
+    {
+        if (g_LogFile)
+            return;
+        std::wstring logPath = JoinPath(directory, L"DELibInitializer.log");
+        g_LogFile = _wfopen(logPath.c_str(), L"w");
+    }
+
+    void Log(const wchar_t* fmt, ...)
+    {
+        wchar_t buf[512];
+        va_list args;
+        va_start(args, fmt);
+        vswprintf(buf, 512, fmt, args);
+        va_end(args);
+
+        OutputDebugStringW(buf);
+
+        if (g_LogFile)
+        {
+            fwprintf(g_LogFile, L"%s", buf);
+            fflush(g_LogFile);
+        }
+    }
+
+    using InitializeManagedFn = int(CORECLR_DELEGATE_CALLTYPE*)(const wchar_t*);
+
+    DotNetHost g_Host;
+
+    // Runs the whole managed init sequence on its own thread. hostfxr/CoreCLR
+    // initialization touches the loader and pumps callbacks internally, doing
+    // this directly inside DllMain (which holds the loader lock) risks a deadlock.
+    DWORD WINAPI InitThreadProc(LPVOID param)
+    {
+        HMODULE module = reinterpret_cast<HMODULE>(param);
+
+        std::wstring directory = GetModuleDirectory(module);
+        if (directory.empty())
+        {
+            OutputDebugStringW(L"[DELibInitializer] Failed to resolve module directory\n");
+            ExitThread(1);
+        }
+
+        OpenLogFile(directory);
+        Log(L"[DELibInitializer] Starting from %s\n", directory.c_str());
+
+        std::wstring assemblyPath = JoinPath(directory, L"DELibrary.NET.dll");
+        std::wstring runtimeConfigPath = JoinPath(directory, L"DELibrary.NET.runtimeconfig.json");
+
+        if (GetFileAttributesW(runtimeConfigPath.c_str()) == INVALID_FILE_ATTRIBUTES)
+        {
+            Log(L"[DELibInitializer] Missing runtimeconfig.json at %s\n", runtimeConfigPath.c_str());
+            ExitThread(1);
+        }
+
+        if (!g_Host.Initialize(runtimeConfigPath))
+        {
+            Log(L"[DELibInitializer] Failed to initialize CoreCLR via hostfxr\n");
+            ExitThread(1);
+        }
+
+        InitializeManagedFn initialize = nullptr;
+
+        if (!g_Host.GetManagedFunction(
+            assemblyPath,
+            L"DragonEngineLibrary.Entry, DELibrary.NET",
+            L"Initialize",
+            L"DragonEngineLibrary.InitializeDelegate, DELibrary.NET",
+            initialize))
+        {
+            Log(L"[DELibInitializer] Failed to resolve DragonEngineLibrary.Entry.Initialize\n");
+            ExitThread(1);
+        }
+
+        int result = initialize(directory.c_str());
+        Log(L"[DELibInitializer] DragonEngineLibrary.Entry.Initialize returned %d\n", result);
+
+        ExitThread(0);
+        return 0;
+    }
+}
+
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD reasonForCall, LPVOID)
+{
+    if (reasonForCall == DLL_PROCESS_ATTACH)
+    {
+        // Note: intentionally never freed via FreeLibraryAndExitThread. This module
+        // has to stay mapped for the life of the process, cimgui.dll/Y7Internal.dll/
+        // DELibrary.NET.dll all stay resident the same way for the whole session.
+        CloseHandle(CreateThread(nullptr, 0, InitThreadProc, hModule, 0, nullptr));
+    }
+
+    return TRUE;
+}

--- a/DELibrary.NET.Loader/App.config
+++ b/DELibrary.NET.Loader/App.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
-    </startup>
-</configuration>

--- a/DELibrary.NET.Loader/DELibrary.Loader.csproj
+++ b/DELibrary.NET.Loader/DELibrary.Loader.csproj
@@ -1,57 +1,21 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{A91ADD10-BB77-4699-829B-B6861A839906}</ProjectGuid>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <RootNamespace>DELibrary.Loader</RootNamespace>
     <AssemblyName>DELibrary.Loader</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <Optimize>true</Optimize>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>
-    </PostBuildEvent>
-  </PropertyGroup>
+
 </Project>

--- a/DELibrary.NET.Loader/Properties/AssemblyInfo.cs
+++ b/DELibrary.NET.Loader/Properties/AssemblyInfo.cs
@@ -6,9 +6,9 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("DELibrary.Loader")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("Loader for DELibrary.NET")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Fronkln")]
 [assembly: AssemblyProduct("DELibrary.Loader")]
 [assembly: AssemblyCopyright("Copyright ©  2023")]
 [assembly: AssemblyTrademark("")]

--- a/DELibrary.NET/Advanced/DXHook.cs
+++ b/DELibrary.NET/Advanced/DXHook.cs
@@ -17,11 +17,20 @@ namespace DragonEngineLibrary.Advanced
         [DllImport("cimgui.dll", EntryPoint = "Register_Present_Function", CallingConvention = CallingConvention.Cdecl)]
         internal static extern void DELibrary_DXHook_RegisterPresentFunc(IntPtr addr);
 
+        [DllImport("cimgui.dll", EntryPoint = "Unregister_Present_Function", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void DELibrary_DXHook_UnregisterPresentFunc(IntPtr addr);
+
         [DllImport("cimgui.dll", EntryPoint = "Register_PreFirstFrame_Function", CallingConvention = CallingConvention.Cdecl)]
         internal static extern void DELibrary_DXHook_RegisterPreFirstFrameFunc(IntPtr addr);
 
+        [DllImport("cimgui.dll", EntryPoint = "Unregister_PreFirstFrame_Function", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void DELibrary_DXHook_UnregisterPreFirstFrameFunc(IntPtr addr);
+
         [DllImport("cimgui.dll", EntryPoint = "Register_WndProc_Function", CallingConvention = CallingConvention.Cdecl)]
         internal static extern void DELibrary_DXHook_RegisterWndProcFunc(IntPtr addr);
+
+        [DllImport("cimgui.dll", EntryPoint = "Unregister_WndProc_Function", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void DELibrary_DXHook_UnregisterWndProcFunc(IntPtr addr);
 
         [DllImport("cimgui.dll", EntryPoint = "GetGameHwnd", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr GetGameHwnd();

--- a/DELibrary.NET/Advanced/ImGui.cs
+++ b/DELibrary.NET/Advanced/ImGui.cs
@@ -13,6 +13,8 @@ namespace DragonEngineLibrary.Advanced
     {
         internal delegate void DX11Present();
         private static List<DX11Present> _dx11Delegates = new List<DX11Present>();
+        private static Dictionary<Action, DX11Present> _uiUpdateDelegates = new Dictionary<Action, DX11Present>();
+        private static Dictionary<Action, DX11Present> _preFirstFrameDelegates = new Dictionary<Action, DX11Present>();
 
         public static bool toInit = false;
 
@@ -25,12 +27,26 @@ namespace DragonEngineLibrary.Advanced
             Action safeFunc = CreateSafeCallback(func, funcName);
             DX11Present del = new DX11Present(safeFunc);
             _dx11Delegates.Add(del);
+            _uiUpdateDelegates[func] = del;
             // JIT-compile the target on this thread so type initializers don't run
             // on the DX11 render thread when the native callback fires.
             try { System.Runtime.CompilerServices.RuntimeHelpers.PrepareDelegate(del); } catch { }
 
             DXHook.DELibrary_DXHook_RegisterPresentFunc(Marshal.GetFunctionPointerForDelegate(del));
             DragonEngine.Log("[ImGui] RegisterUIUpdate done", Logger.Event.DEBUG);
+        }
+
+        /// <summary>
+        /// Unregister a callback previously passed to RegisterUIUpdate.
+        /// </summary>
+        public static void UnregisterUIUpdate(Action func)
+        {
+            if (!_uiUpdateDelegates.TryGetValue(func, out DX11Present del)) return;
+
+            DXHook.DELibrary_DXHook_UnregisterPresentFunc(Marshal.GetFunctionPointerForDelegate(del));
+            _uiUpdateDelegates.Remove(func);
+            _dx11Delegates.Remove(del);
+            DragonEngine.Log($"[ImGui] UnregisterUIUpdate: {func.Method.Name}", Logger.Event.DEBUG);
         }
 
         /// <summary>
@@ -42,6 +58,7 @@ namespace DragonEngineLibrary.Advanced
             DragonEngine.Log($"[ImGui] RegisterPreFirstFrame: {func.Method.Name}", Logger.Event.DEBUG);
             DX11Present del = new DX11Present(func);
             _dx11Delegates.Add(del);
+            _preFirstFrameDelegates[func] = del;
             // Same JIT pre-warm for pre-first-frame callbacks.
             try { System.Runtime.CompilerServices.RuntimeHelpers.PrepareDelegate(del); } catch { }
 
@@ -49,8 +66,22 @@ namespace DragonEngineLibrary.Advanced
             DragonEngine.Log("[ImGui] RegisterPreFirstFrame done", Logger.Event.DEBUG);
         }
 
+        /// <summary>
+        /// Unregister a callback previously passed to RegisterPreFirstFrame.
+        /// </summary>
+        public static void UnregisterPreFirstFrame(Action func)
+        {
+            if (!_preFirstFrameDelegates.TryGetValue(func, out DX11Present del)) return;
+
+            DXHook.DELibrary_DXHook_UnregisterPreFirstFrameFunc(Marshal.GetFunctionPointerForDelegate(del));
+            _preFirstFrameDelegates.Remove(func);
+            _dx11Delegates.Remove(del);
+            DragonEngine.Log($"[ImGui] UnregisterPreFirstFrame: {func.Method.Name}", Logger.Event.DEBUG);
+        }
+
         internal delegate void WndProcDelegate(IntPtr hwnd, int msg, IntPtr wparam, IntPtr lparam);
         private static List<WndProcDelegate> _wndProcDelegates = new List<WndProcDelegate>();
+        private static Dictionary<Action<IntPtr, int, IntPtr, IntPtr>, WndProcDelegate> _wndProcMap = new Dictionary<Action<IntPtr, int, IntPtr, IntPtr>, WndProcDelegate>();
 
         /// <summary>
         /// Register a WndProc callback through cimgui's window subclass.
@@ -61,8 +92,21 @@ namespace DragonEngineLibrary.Advanced
         {
             WndProcDelegate del = new WndProcDelegate(func);
             _wndProcDelegates.Add(del);
+            _wndProcMap[func] = del;
 
             DXHook.DELibrary_DXHook_RegisterWndProcFunc(Marshal.GetFunctionPointerForDelegate(del));
+        }
+
+        /// <summary>
+        /// Unregister a callback previously passed to RegisterWndProc.
+        /// </summary>
+        public static void UnregisterWndProc(Action<IntPtr, int, IntPtr, IntPtr> func)
+        {
+            if (!_wndProcMap.TryGetValue(func, out WndProcDelegate del)) return;
+
+            DXHook.DELibrary_DXHook_UnregisterWndProcFunc(Marshal.GetFunctionPointerForDelegate(del));
+            _wndProcMap.Remove(func);
+            _wndProcDelegates.Remove(del);
         }
 
         public static void Init()

--- a/DELibrary.NET/Advanced/ImGui.cs
+++ b/DELibrary.NET/Advanced/ImGui.cs
@@ -18,8 +18,21 @@ namespace DragonEngineLibrary.Advanced
 
         public static bool toInit = false;
 
+        // Whether Init() has run. Registering a callback before the DX hook is
+        // installed just appends to a native array that nothing drains, so it
+        // renders nothing with no error. The Register* methods below lazily
+        // ensure Init() has run once so mods don't have to remember to call it.
+        private static bool _initialized = false;
+
+        private static void EnsureInitialized()
+        {
+            if (!_initialized)
+                Init();
+        }
+
         public static void RegisterUIUpdate(Action func)
         {
+            EnsureInitialized();
             DragonEngine.Log($"[ImGui] RegisterUIUpdate: {func.Method.Name}", Logger.Event.DEBUG);
             // Wrap in try/catch so exceptions don't propagate into native SEH
             // (which swallows them with no diagnostic info on DX12)
@@ -55,6 +68,7 @@ namespace DragonEngineLibrary.Advanced
         /// </summary>
         public static void RegisterPreFirstFrame(Action func)
         {
+            EnsureInitialized();
             DragonEngine.Log($"[ImGui] RegisterPreFirstFrame: {func.Method.Name}", Logger.Event.DEBUG);
             DX11Present del = new DX11Present(func);
             _dx11Delegates.Add(del);
@@ -90,6 +104,7 @@ namespace DragonEngineLibrary.Advanced
         /// </summary>
         public static void RegisterWndProc(Action<IntPtr, int, IntPtr, IntPtr> func)
         {
+            EnsureInitialized();
             WndProcDelegate del = new WndProcDelegate(func);
             _wndProcDelegates.Add(del);
             _wndProcMap[func] = del;
@@ -111,6 +126,13 @@ namespace DragonEngineLibrary.Advanced
 
         public static void Init()
         {
+            // Idempotent: mods may call this explicitly and the Register* methods
+            // also call it lazily. Loading cimgui twice / re-running MH_CreateHook
+            // would fail, so only the first call does the work.
+            if (_initialized)
+                return;
+            _initialized = true;
+
             DragonEngine.Log("[ImGui] Init() called", Logger.Event.DEBUG);
             string libPath = Path.Combine(Entry.Root, "Y7Internal.dll");
             string cimguiPath = Path.Combine(new FileInfo(libPath).Directory.FullName, "cimgui.dll");

--- a/DELibrary.NET/DELibrary.NET.csproj
+++ b/DELibrary.NET/DELibrary.NET.csproj
@@ -1,15 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
     <TargetExt>.dll</TargetExt>
     <RootNamespace>DragonEngineLibrary</RootNamespace>
     <AssemblyName>DELibrary.NET</AssemblyName>
-    <LangVersion>7.3</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Deterministic>true</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <!-- Library output types don't get a runtimeconfig.json by default, but DELibInitializer
+         hosts this assembly directly via hostfxr and needs one to resolve the runtime. -->
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <!-- Without Costura, transitive NuGet deps (HexaGen.Runtime) only get recorded in
+         deps.json pointing at the NuGet cache path, which won't exist on a player's
+         machine. Force them to be copied next to the dll instead. -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
@@ -74,12 +80,9 @@
     <PlatformTarget>x64</PlatformTarget>
     <DefineConstants>TRACE;DEBUG;IW;K2_AND_UP;JE_AND_UP;YLAD_AND_UP;GAIDEN_AND_UP;IW_AND_UP;TURN_BASED_GAME</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <RegisterForComInterop>true</RegisterForComInterop>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
-    <Prefer32Bit>true</Prefer32Bit>
     <WarningLevel>5</WarningLevel>
     <OutputPath>bin\x64\Infinite Wealth Debug\</OutputPath>
   </PropertyGroup>
@@ -169,12 +172,6 @@
     <Optimize>true</Optimize>
   </PropertyGroup>
 
-
-  <ItemGroup>
-    <PackageReference Include="Costura.Fody" Version="6.0.0" PrivateAssets="all" />
-    <PackageReference Include="Fody" Version="6.9.3" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" PrivateAssets="all" />
-  </ItemGroup>
 
 
   <ItemGroup>

--- a/DELibrary.NET/Entry.cs
+++ b/DELibrary.NET/Entry.cs
@@ -1,27 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
+using System;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace DragonEngineLibrary
 {
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     public delegate int InitializeDelegate(IntPtr gameDirectory);
-
-    public static class Entrya
-    {
-        public static int Initialize(IntPtr gameDirectory)
-        {
-            string directory = Marshal.PtrToStringUni(gameDirectory);
-
-            Process.Start("explorer", "http://google.com");
-            Console.WriteLine($"Environment.Version: {Environment.Version}");
-            Console.WriteLine($"RuntimeInformation.FrameworkDescription: {RuntimeInformation.FrameworkDescription}");
-
-            // Do your startup here.
-
-            return 0;
-        }
-    }
 }

--- a/DELibrary.NET/FodyWeavers.xml
+++ b/DELibrary.NET/FodyWeavers.xml
@@ -1,3 +1,0 @@
-﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd" GenerateXsd="false">
-  <Costura />
-</Weavers>

--- a/DELibrary.NET/Program.cs
+++ b/DELibrary.NET/Program.cs
@@ -64,8 +64,30 @@ namespace DragonEngineLibrary
             {
                 string assemblyName = args.Name.Split(',')[0];
 
-                if (assemblyName == "DELibrary.NET")
-                    return AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(x => x.GetName().Name == "DELibrary.NET");
+                // Resolve against an already-loaded assembly by simple name. Covers
+                // DELibrary.NET and any binding a mod references that's already loaded,
+                // and ignores version differences (a mod built against a slightly
+                // different binding version than the one that ships).
+                var loaded = AppDomain.CurrentDomain.GetAssemblies()
+                    .FirstOrDefault(x => x.GetName().Name == assemblyName);
+                if (loaded != null)
+                    return loaded;
+
+                // Not loaded yet: the ImGui/ImPlot/ImNodes/ImGuizmo bindings and
+                // HexaGen.Runtime ship as separate files next to DELibrary.NET now
+                // that Costura no longer merges them in. A mod loaded from the mods
+                // folder doesn't probe that directory, so load it from Root (the DE
+                // Library folder where DELibrary.NET.dll and the bindings live).
+                try
+                {
+                    if (!string.IsNullOrEmpty(Root))
+                    {
+                        string candidate = Path.Combine(Root, assemblyName + ".dll");
+                        if (File.Exists(candidate))
+                            return System.Reflection.Assembly.LoadFrom(candidate);
+                    }
+                }
+                catch { }
 
                 return null;
             };

--- a/DELibrary.NET/Program.cs
+++ b/DELibrary.NET/Program.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Runtime.InteropServices;
 using System.IO;
-using System.Windows.Input;
 using System.Security.AccessControl;
 using System.Diagnostics;
 

--- a/DELibrary.NET/Program.cs
+++ b/DELibrary.NET/Program.cs
@@ -22,8 +22,6 @@ namespace DragonEngineLibrary
         public static string BaseDirectory;
         public static string Root;
 
-        private delegate void InitializeDelegate(IntPtr turnManager);
-
         //Do whatever you want here
         static void ThreadTest()
         {

--- a/DELibrary.NET/Properties/AssemblyInfo.cs
+++ b/DELibrary.NET/Properties/AssemblyInfo.cs
@@ -6,9 +6,9 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("DELibrary.NET")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription(".NET library for Dragon Engine")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Fronkln")]
 [assembly: AssemblyProduct("DELibrary.NET")]
 [assembly: AssemblyCopyright("Copyright ©  2022")]
 [assembly: AssemblyTrademark("")]

--- a/deps/dxhook/dxhook.cpp
+++ b/deps/dxhook/dxhook.cpp
@@ -949,6 +949,20 @@ __declspec(dllexport) void Register_Present_Function(void* callback)
         g_PresentCallbacks[g_PresentCallbackCount++] = (ManagedCallback)callback;
 }
 
+__declspec(dllexport) void Unregister_Present_Function(void* callback)
+{
+    for (int i = 0; i < g_PresentCallbackCount; i++)
+    {
+        if (g_PresentCallbacks[i] != (ManagedCallback)callback) continue;
+        HookLog("[DXHook] Unregister_Present_Function(%p) count=%d->%d\n",
+            callback, g_PresentCallbackCount, g_PresentCallbackCount - 1);
+        for (int j = i; j < g_PresentCallbackCount - 1; j++)
+            g_PresentCallbacks[j] = g_PresentCallbacks[j + 1];
+        g_PresentCallbacks[--g_PresentCallbackCount] = nullptr;
+        break;
+    }
+}
+
 __declspec(dllexport) void Register_PreFirstFrame_Function(void* callback)
 {
     HookLog("[DXHook] Register_PreFirstFrame_Function(%p) count=%d->%d\n",
@@ -957,10 +971,36 @@ __declspec(dllexport) void Register_PreFirstFrame_Function(void* callback)
         g_PreFirstFrameCallbacks[g_PreFirstFrameCallbackCount++] = (ManagedCallback)callback;
 }
 
+__declspec(dllexport) void Unregister_PreFirstFrame_Function(void* callback)
+{
+    for (int i = 0; i < g_PreFirstFrameCallbackCount; i++)
+    {
+        if (g_PreFirstFrameCallbacks[i] != (ManagedCallback)callback) continue;
+        HookLog("[DXHook] Unregister_PreFirstFrame_Function(%p) count=%d->%d\n",
+            callback, g_PreFirstFrameCallbackCount, g_PreFirstFrameCallbackCount - 1);
+        for (int j = i; j < g_PreFirstFrameCallbackCount - 1; j++)
+            g_PreFirstFrameCallbacks[j] = g_PreFirstFrameCallbacks[j + 1];
+        g_PreFirstFrameCallbacks[--g_PreFirstFrameCallbackCount] = nullptr;
+        break;
+    }
+}
+
 __declspec(dllexport) void Register_WndProc_Function(void* callback)
 {
     if (g_WndProcCallbackCount < MAX_WNDPROC_CALLBACKS)
         g_WndProcCallbacks[g_WndProcCallbackCount++] = (WndProcCallback)callback;
+}
+
+__declspec(dllexport) void Unregister_WndProc_Function(void* callback)
+{
+    for (int i = 0; i < g_WndProcCallbackCount; i++)
+    {
+        if (g_WndProcCallbacks[i] != (WndProcCallback)callback) continue;
+        for (int j = i; j < g_WndProcCallbackCount - 1; j++)
+            g_WndProcCallbacks[j] = g_WndProcCallbacks[j + 1];
+        g_WndProcCallbacks[--g_WndProcCallbackCount] = nullptr;
+        break;
+    }
 }
 
 __declspec(dllexport) int CheckImGuiContext()


### PR DESCRIPTION
## Summary

Migrates DELibrary.NET and its projects from .NET Framework 4.8 to .NET 10, adds a hostfxr-based native host so the library starts without the classic mscoree hosting path, and adds a GitHub Actions workflow that builds every native and managed piece.

## Changes

**.NET 10 migration**
- Retarget DELibrary.NET and DELibrary.NET.Loader to net10.0 (SDK-style projects).
- Drop Costura.Fody. The binding DLLs (ImGui/ImPlot/ImNodes/ImGuizmo) and HexaGen.Runtime now ship alongside the main DLL instead of being merged in. This needs `CopyLocalLockFileAssemblies` so those land in the output, and `GenerateRuntimeConfigurationFiles` so the hosted library gets a runtimeconfig.json.
- Fill in the PE version info (AssemblyDescription/AssemblyCompany) that was blank.

**DELibInitializer (native host)**
- New native host that starts CoreCLR through nethost/hostfxr and calls `DragonEngineLibrary.Entry.Initialize`, replacing the classic CLRCreateInstance/mscoree path. Based on Jhrino's source, with the init work moved off the loader lock onto its own thread, logging to DELibInitializer.log, and a check for a missing runtimeconfig.json.
- nethost is statically linked (`NETHOST_USE_AS_STATIC` + libnethost.lib) so the .asi has no runtime dependency on a co-located nethost.dll. Some ASI loaders LoadLibrary plugins with a search scope that excludes the plugin's own directory, which broke resolving nethost.dll (error 126).

**DX hook**
- Add `Unregister_Present_Function` / `Unregister_PreFirstFrame_Function` / `Unregister_WndProc_Function` exports so a mod that unloads does not leave stale native callback pointers into freed managed delegates. The C# side keeps a map from the caller's original delegate to the wrapped one so unregister can find the right function pointer.

**ImGui init**
- `RegisterUIUpdate` / `RegisterPreFirstFrame` / `RegisterWndProc` now run `Init()` on first use. Registering a callback before `Init()` ran only appended to a native array that nothing drains, because the present hook was not installed yet, so it rendered nothing with no error. `Init()` is idempotent so an explicit call plus the lazy path cannot double-load cimgui or re-run MH_CreateHook.
- Removed leftover scratch code (an Entry test class that opened a browser, and a dead delegate).

**CI**
- GitHub Actions workflow builds cimgui.dll (CMake), DELibInitializer.asi (CMake), and DELibrary.NET for every game config, uploading the results as artifacts. No release automation, releases stay manual.

## Testing

Built and run live end to end on:
- Like a Dragon: Infinite Wealth (DX12)
- Yakuza: Like a Dragon / YLAD (DX11)

Confirmed the full chain in-game: the .asi loads, hostfxr starts CoreCLR on .NET 10, DELibrary.NET loads, a mod's `OnModInit` runs, and ImGui renders over the game. Lost Judgment and Gaiden compile in CI but were not launched.
